### PR TITLE
Update GridSearchBurst.cs

### DIFF
--- a/NSGB/GridSearchBurst.cs
+++ b/NSGB/GridSearchBurst.cs
@@ -250,10 +250,10 @@ namespace BurstGridSearch
 
             };
 
-            entries.Dispose();
-
             var depopulateJobHandle = depopulateJob.Schedule(positions.Length, 128);
             depopulateJobHandle.Complete();
+
+            entries.Dispose();
 
             // ------- Sort (end)
 


### PR DESCRIPTION
Bugfix, entries disposed too early, because still needed in depopulateJob.